### PR TITLE
feat: Woody Puzzle風ゲームの基盤を実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Woody Puzzle</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        body {
+            font-family: 'Arial', sans-serif;
+            background: linear-gradient(135deg, #d4a373 0%, #c19a6b 100%);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
+            min-height: 100vh;
+            padding: 20px 10px;
+            touch-action: none;
+        }
+
+        h1 {
+            color: #3e2723;
+            font-size: 28px;
+            margin-bottom: 20px;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
+        #game-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 30px;
+            width: 100%;
+            max-width: 500px;
+        }
+
+        #board {
+            background: linear-gradient(135deg, #8d6e63 0%, #795548 100%);
+            border-radius: 10px;
+            padding: 10px;
+            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+            display: grid;
+            grid-template-columns: repeat(10, 1fr);
+            gap: 2px;
+            width: 100%;
+            max-width: 400px;
+            aspect-ratio: 1;
+        }
+
+        .cell {
+            background: linear-gradient(135deg, #deb887 0%, #d2b48c 100%);
+            border: 1px solid #8d6e63;
+            border-radius: 2px;
+            aspect-ratio: 1;
+            transition: background 0.2s;
+        }
+
+        .cell.filled {
+            background: linear-gradient(135deg, #6d4c41 0%, #5d4037 100%);
+            border-color: #3e2723;
+        }
+
+        .cell.highlight {
+            background: linear-gradient(135deg, #aed581 0%, #9ccc65 100%);
+        }
+
+        .cell.invalid {
+            background: linear-gradient(135deg, #ef5350 0%, #e53935 100%);
+        }
+
+        #blocks-container {
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+            padding: 20px;
+            background: rgba(141, 110, 99, 0.3);
+            border-radius: 10px;
+            width: 100%;
+            max-width: 400px;
+            min-height: 120px;
+            flex-wrap: wrap;
+        }
+
+        .block {
+            display: grid;
+            gap: 2px;
+            cursor: grab;
+            padding: 5px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 5px;
+            transition: transform 0.2s;
+        }
+
+        .block:hover {
+            transform: scale(1.05);
+        }
+
+        .block.dragging {
+            opacity: 0.5;
+            cursor: grabbing;
+        }
+
+        .block-cell {
+            width: 30px;
+            height: 30px;
+            background: linear-gradient(135deg, #8d6e63 0%, #795548 100%);
+            border: 2px solid #6d4c41;
+            border-radius: 3px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
+        .drag-preview {
+            position: fixed;
+            pointer-events: none;
+            z-index: 1000;
+            opacity: 0.8;
+            display: grid;
+            gap: 2px;
+        }
+
+        .drag-preview .block-cell {
+            width: 30px;
+            height: 30px;
+        }
+
+        @media (max-width: 480px) {
+            h1 {
+                font-size: 24px;
+                margin-bottom: 15px;
+            }
+
+            #board {
+                max-width: 350px;
+            }
+
+            .block-cell {
+                width: 25px;
+                height: 25px;
+            }
+
+            .drag-preview .block-cell {
+                width: 25px;
+                height: 25px;
+            }
+
+            #blocks-container {
+                max-width: 350px;
+                gap: 10px;
+                padding: 15px;
+            }
+        }
+
+        @media (max-width: 380px) {
+            #board {
+                max-width: 300px;
+            }
+
+            .block-cell {
+                width: 22px;
+                height: 22px;
+            }
+
+            .drag-preview .block-cell {
+                width: 22px;
+                height: 22px;
+            }
+
+            #blocks-container {
+                max-width: 300px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <h1>Woody Puzzle</h1>
+
+    <div id="game-container">
+        <div id="board"></div>
+        <div id="blocks-container"></div>
+    </div>
+
+    <script>
+        // ゲーム状態
+        const BOARD_SIZE = 10;
+        const board = Array(BOARD_SIZE).fill(null).map(() => Array(BOARD_SIZE).fill(false));
+        let draggedBlock = null;
+        let dragPreview = null;
+        let currentBlocks = [];
+
+        // ブロックの定義（形状）
+        const blockShapes = [
+            [[1]], // 1x1
+            [[1, 1], [1, 1]], // 2x2
+            [[1, 1, 1]] // 3x1
+        ];
+
+        // ボードの初期化
+        function initBoard() {
+            const boardElement = document.getElementById('board');
+            boardElement.innerHTML = '';
+
+            for (let row = 0; row < BOARD_SIZE; row++) {
+                for (let col = 0; col < BOARD_SIZE; col++) {
+                    const cell = document.createElement('div');
+                    cell.className = 'cell';
+                    cell.dataset.row = row;
+                    cell.dataset.col = col;
+                    boardElement.appendChild(cell);
+                }
+            }
+        }
+
+        // ブロックの初期化
+        function initBlocks() {
+            currentBlocks = blockShapes.map((shape, index) => ({
+                id: index,
+                shape: shape,
+                placed: false
+            }));
+            renderBlocks();
+        }
+
+        // ブロックのレンダリング
+        function renderBlocks() {
+            const container = document.getElementById('blocks-container');
+            container.innerHTML = '';
+
+            currentBlocks.forEach(block => {
+                if (!block.placed) {
+                    const blockElement = createBlockElement(block);
+                    container.appendChild(blockElement);
+                }
+            });
+        }
+
+        // ブロック要素の作成
+        function createBlockElement(block) {
+            const blockDiv = document.createElement('div');
+            blockDiv.className = 'block';
+            blockDiv.dataset.blockId = block.id;
+
+            const rows = block.shape.length;
+            const cols = block.shape[0].length;
+            blockDiv.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+            blockDiv.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
+            block.shape.forEach(row => {
+                row.forEach(cell => {
+                    if (cell) {
+                        const cellDiv = document.createElement('div');
+                        cellDiv.className = 'block-cell';
+                        blockDiv.appendChild(cellDiv);
+                    }
+                });
+            });
+
+            // マウスイベント
+            blockDiv.addEventListener('mousedown', (e) => startDrag(e, block));
+
+            // タッチイベント
+            blockDiv.addEventListener('touchstart', (e) => {
+                e.preventDefault();
+                startDrag(e.touches[0], block);
+            });
+
+            return blockDiv;
+        }
+
+        // ドラッグ開始
+        function startDrag(e, block) {
+            draggedBlock = block;
+
+            // ドラッグプレビューの作成
+            dragPreview = document.createElement('div');
+            dragPreview.className = 'drag-preview';
+            const rows = block.shape.length;
+            const cols = block.shape[0].length;
+            dragPreview.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+            dragPreview.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
+            block.shape.forEach(row => {
+                row.forEach(cell => {
+                    if (cell) {
+                        const cellDiv = document.createElement('div');
+                        cellDiv.className = 'block-cell';
+                        dragPreview.appendChild(cellDiv);
+                    }
+                });
+            });
+
+            document.body.appendChild(dragPreview);
+            updateDragPreview(e.clientX || e.pageX, e.clientY || e.pageY);
+
+            // イベントリスナーの追加
+            document.addEventListener('mousemove', onDragMove);
+            document.addEventListener('mouseup', onDragEnd);
+            document.addEventListener('touchmove', onTouchMove);
+            document.addEventListener('touchend', onDragEnd);
+
+            // ドラッグ中のブロックを半透明に
+            const blockElement = document.querySelector(`[data-block-id="${block.id}"]`);
+            if (blockElement) {
+                blockElement.classList.add('dragging');
+            }
+        }
+
+        // ドラッグ中（マウス）
+        function onDragMove(e) {
+            if (!draggedBlock) return;
+            updateDragPreview(e.clientX, e.clientY);
+            highlightCells(e.clientX, e.clientY);
+        }
+
+        // ドラッグ中（タッチ）
+        function onTouchMove(e) {
+            if (!draggedBlock) return;
+            e.preventDefault();
+            const touch = e.touches[0];
+            updateDragPreview(touch.clientX, touch.clientY);
+            highlightCells(touch.clientX, touch.clientY);
+        }
+
+        // ドラッグプレビューの更新
+        function updateDragPreview(x, y) {
+            if (dragPreview) {
+                dragPreview.style.left = (x - 40) + 'px';
+                dragPreview.style.top = (y - 40) + 'px';
+            }
+        }
+
+        // セルのハイライト
+        function highlightCells(x, y) {
+            // すべてのハイライトをクリア
+            document.querySelectorAll('.cell').forEach(cell => {
+                cell.classList.remove('highlight', 'invalid');
+            });
+
+            const boardRect = document.getElementById('board').getBoundingClientRect();
+            const cellSize = boardRect.width / BOARD_SIZE;
+
+            // ボード上の位置を計算
+            const col = Math.floor((x - boardRect.left) / cellSize);
+            const row = Math.floor((y - boardRect.top) / cellSize);
+
+            if (col < 0 || col >= BOARD_SIZE || row < 0 || row >= BOARD_SIZE) return;
+
+            // ブロックが配置可能かチェック
+            const canPlace = checkPlacement(row, col, draggedBlock.shape);
+            const className = canPlace ? 'highlight' : 'invalid';
+
+            // ハイライトを適用
+            draggedBlock.shape.forEach((shapeRow, r) => {
+                shapeRow.forEach((cell, c) => {
+                    if (cell) {
+                        const targetRow = row + r;
+                        const targetCol = col + c;
+                        if (targetRow >= 0 && targetRow < BOARD_SIZE &&
+                            targetCol >= 0 && targetCol < BOARD_SIZE) {
+                            const cellElement = document.querySelector(
+                                `[data-row="${targetRow}"][data-col="${targetCol}"]`
+                            );
+                            if (cellElement) {
+                                cellElement.classList.add(className);
+                            }
+                        }
+                    }
+                });
+            });
+        }
+
+        // 配置可能かチェック
+        function checkPlacement(row, col, shape) {
+            for (let r = 0; r < shape.length; r++) {
+                for (let c = 0; c < shape[0].length; c++) {
+                    if (shape[r][c]) {
+                        const targetRow = row + r;
+                        const targetCol = col + c;
+
+                        // ボードの範囲外
+                        if (targetRow < 0 || targetRow >= BOARD_SIZE ||
+                            targetCol < 0 || targetCol >= BOARD_SIZE) {
+                            return false;
+                        }
+
+                        // すでに埋まっている
+                        if (board[targetRow][targetCol]) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        // ブロックを配置
+        function placeBlock(row, col, block) {
+            block.shape.forEach((shapeRow, r) => {
+                shapeRow.forEach((cell, c) => {
+                    if (cell) {
+                        const targetRow = row + r;
+                        const targetCol = col + c;
+                        board[targetRow][targetCol] = true;
+
+                        const cellElement = document.querySelector(
+                            `[data-row="${targetRow}"][data-col="${targetCol}"]`
+                        );
+                        if (cellElement) {
+                            cellElement.classList.add('filled');
+                            cellElement.classList.remove('highlight', 'invalid');
+                        }
+                    }
+                });
+            });
+
+            block.placed = true;
+            renderBlocks();
+        }
+
+        // ドラッグ終了
+        function onDragEnd(e) {
+            if (!draggedBlock) return;
+
+            const x = e.clientX || (e.changedTouches && e.changedTouches[0].clientX);
+            const y = e.clientY || (e.changedTouches && e.changedTouches[0].clientY);
+
+            const boardRect = document.getElementById('board').getBoundingClientRect();
+            const cellSize = boardRect.width / BOARD_SIZE;
+
+            const col = Math.floor((x - boardRect.left) / cellSize);
+            const row = Math.floor((y - boardRect.top) / cellSize);
+
+            // 配置可能な場合のみ配置
+            if (checkPlacement(row, col, draggedBlock.shape)) {
+                placeBlock(row, col, draggedBlock);
+            }
+
+            // クリーンアップ
+            document.querySelectorAll('.cell').forEach(cell => {
+                cell.classList.remove('highlight', 'invalid');
+            });
+
+            const blockElement = document.querySelector(`[data-block-id="${draggedBlock.id}"]`);
+            if (blockElement) {
+                blockElement.classList.remove('dragging');
+            }
+
+            if (dragPreview) {
+                dragPreview.remove();
+                dragPreview = null;
+            }
+
+            document.removeEventListener('mousemove', onDragMove);
+            document.removeEventListener('mouseup', onDragEnd);
+            document.removeEventListener('touchmove', onTouchMove);
+            document.removeEventListener('touchend', onDragEnd);
+
+            draggedBlock = null;
+        }
+
+        // ゲームの初期化
+        initBoard();
+        initBlocks();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
Woody Puzzle風パズルゲームの基盤を実装しました。

## 実装内容
- 10×10マスのゲームボード（木目調デザイン）
- 3つのブロック表示エリア（1×1、2×2、3×1）
- ドラッグ&ドロップ機能（マウス・タッチ対応）
- 配置検証（重複不可、範囲外不可）
- レスポンシブデザイン（スマホ対応）

## 関連Issue
Closes #4

———
Generated with [Claude Code](https://claude.ai/code)