### PR TITLE
Fix block shape display inconsistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,11 +490,15 @@
 
             block.shape.forEach(row => {
                 row.forEach(cell => {
+                    const cellDiv = document.createElement('div');
                     if (cell) {
-                        const cellDiv = document.createElement('div');
                         cellDiv.className = 'block-cell';
-                        blockDiv.appendChild(cellDiv);
+                    } else {
+                        cellDiv.style.visibility = 'hidden';
+                        cellDiv.style.width = '30px';
+                        cellDiv.style.height = '30px';
                     }
+                    blockDiv.appendChild(cellDiv);
                 });
             });
 
@@ -524,11 +528,15 @@
 
             block.shape.forEach(row => {
                 row.forEach(cell => {
+                    const cellDiv = document.createElement('div');
                     if (cell) {
-                        const cellDiv = document.createElement('div');
                         cellDiv.className = 'block-cell';
-                        dragPreview.appendChild(cellDiv);
+                    } else {
+                        cellDiv.style.visibility = 'hidden';
+                        cellDiv.style.width = '30px';
+                        cellDiv.style.height = '30px';
                     }
+                    dragPreview.appendChild(cellDiv);
                 });
             });
 


### PR DESCRIPTION
Fixes #12

This PR fixes the bug where blocks appeared differently in the stock area versus when dragged and dropped.

### Changes
- Modified `createBlockElement()` to create invisible placeholder elements for empty cells
- Modified `startDrag()` to maintain consistent grid structure in drag preview
- Empty cells now use `visibility: hidden` to preserve grid layout without visible elements

### Testing
Blocks with complex shapes (like L-shapes and T-shapes) now display consistently between stock and drag states.

Generated with [Claude Code](https://claude.ai/code)