### PR TITLE
Fix block display gaps in Stock

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
 
         .block {
             display: grid;
-            gap: 2px;
+            gap: 0px;
             cursor: grab;
             padding: 5px;
             background: rgba(255, 255, 255, 0.1);
@@ -214,7 +214,7 @@
             z-index: 1000;
             opacity: 0.8;
             display: grid;
-            gap: 2px;
+            gap: 0px;
         }
 
         .drag-preview .block-cell {


### PR DESCRIPTION
Remove 2px gap between grid cells in block display to prevent visual gaps between rows in Stock area.

Changes:
- Set .block gap to 0px (was 2px)
- Set .drag-preview gap to 0px (was 2px)

Fixes #14

Generated with [Claude Code](https://claude.ai/code)