### PR TITLE
feat: バージョン情報に日本時間(時分)を表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,24 @@
     </style>
 </head>
 <body>
-    <div id="version-display">Version: 2026-01-07</div>
+    <div id="version-display"></div>
+    <script>
+        // バージョン情報を日本時間で表示
+        (function() {
+            const now = new Date();
+            const jstOffset = 9 * 60; // JST is UTC+9
+            const jstDate = new Date(now.getTime() + (jstOffset + now.getTimezoneOffset()) * 60000);
+
+            const year = jstDate.getFullYear();
+            const month = String(jstDate.getMonth() + 1).padStart(2, '0');
+            const day = String(jstDate.getDate()).padStart(2, '0');
+            const hours = String(jstDate.getHours()).padStart(2, '0');
+            const minutes = String(jstDate.getMinutes()).padStart(2, '0');
+
+            document.getElementById('version-display').textContent =
+                `Version: ${year}-${month}-${day} ${hours}:${minutes} JST`;
+        })();
+    </script>
     <h1>Woody Puzzle</h1>
     <div id="score-display">スコア: 0</div>
     <div id="highscore-display">ハイスコア: 0</div>


### PR DESCRIPTION
## Summary

バージョン情報の表示を改善し、日付だけでなく時刻(時:分)も表示するようにしました。

## Changes

- `index.html`のバージョン表示を動的に生成するように変更
- 日本標準時(JST)で時刻を表示
- フォーマット: `Version: YYYY-MM-DD HH:MM JST`

Fixes #18

Generated with [Claude Code](https://claude.ai/code)