### PR TITLE
fix: Stockのブロック間の隙間を修正

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -81,12 +81,9 @@ var BlockManager = {
         block.shape.forEach(row => {
             row.forEach(cell => {
                 const cellDiv = document.createElement('div');
-                if (cell) {
-                    cellDiv.className = 'block-cell';
-                } else {
+                cellDiv.className = 'block-cell';
+                if (!cell) {
                     cellDiv.style.visibility = 'hidden';
-                    cellDiv.style.width = '30px';
-                    cellDiv.style.height = '30px';
                 }
                 blockDiv.appendChild(cellDiv);
             });

--- a/js/input.js
+++ b/js/input.js
@@ -20,12 +20,9 @@ var InputHandler = {
         block.shape.forEach(row => {
             row.forEach(cell => {
                 const cellDiv = document.createElement('div');
-                if (cell) {
-                    cellDiv.className = 'block-cell';
-                } else {
+                cellDiv.className = 'block-cell';
+                if (!cell) {
                     cellDiv.style.visibility = 'hidden';
-                    cellDiv.style.width = '30px';
-                    cellDiv.style.height = '30px';
                 }
                 this.dragPreview.appendChild(cellDiv);
             });


### PR DESCRIPTION
空セル(値0)を含むブロックの描画において、空セルに block-cell クラスが適用されていなかったため、可視セルとサイズが一致せず隙間が発生していました。

Fixes #24

Generated with [Claude Code](https://claude.ai/code)