### PR TITLE
fix: ストックエリアのブロック表示の隙間を修正

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -75,8 +75,8 @@ var BlockManager = {
 
         const rows = block.shape.length;
         const cols = block.shape[0].length;
-        blockDiv.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-        blockDiv.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+        blockDiv.style.gridTemplateColumns = `repeat(${cols}, auto)`;
+        blockDiv.style.gridTemplateRows = `repeat(${rows}, auto)`;
 
         block.shape.forEach(row => {
             row.forEach(cell => {

--- a/js/input.js
+++ b/js/input.js
@@ -14,8 +14,8 @@ var InputHandler = {
         this.dragPreview.className = 'drag-preview';
         const rows = block.shape.length;
         const cols = block.shape[0].length;
-        this.dragPreview.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-        this.dragPreview.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+        this.dragPreview.style.gridTemplateColumns = `repeat(${cols}, auto)`;
+        this.dragPreview.style.gridTemplateRows = `repeat(${rows}, auto)`;
 
         block.shape.forEach(row => {
             row.forEach(cell => {


### PR DESCRIPTION
## 変更内容
ストックエリア（画面下部）のブロック表示で、セル間の隙間を修正しました。

## 修正内容
- `js/block.js`: CSS Gridの設定を `1fr` から `auto` に変更
- `js/input.js`: ドラッグプレビューでも同様に修正

## 原因
CSS Gridで `1fr` を使用していたため、固定サイズ(30px)のセル間に余分なスペースが発生していました。`auto` に変更することで、グリッドセルがコンテンツサイズにぴったり合うようになり、隙間がなくなります。

Closes #26

---

Generated with [Claude Code](https://claude.ai/code)