### PR TITLE
fix: ストックエリアのブロックセル間の隙間を修正

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -75,8 +75,8 @@ var BlockManager = {
 
         const rows = block.shape.length;
         const cols = block.shape[0].length;
-        blockDiv.style.gridTemplateColumns = `repeat(${cols}, auto)`;
-        blockDiv.style.gridTemplateRows = `repeat(${rows}, auto)`;
+        blockDiv.style.gridTemplateColumns = `repeat(${cols}, 30px)`;
+        blockDiv.style.gridTemplateRows = `repeat(${rows}, 30px)`;
 
         block.shape.forEach(row => {
             row.forEach(cell => {

--- a/js/input.js
+++ b/js/input.js
@@ -14,8 +14,8 @@ var InputHandler = {
         this.dragPreview.className = 'drag-preview';
         const rows = block.shape.length;
         const cols = block.shape[0].length;
-        this.dragPreview.style.gridTemplateColumns = `repeat(${cols}, auto)`;
-        this.dragPreview.style.gridTemplateRows = `repeat(${rows}, auto)`;
+        this.dragPreview.style.gridTemplateColumns = `repeat(${cols}, 30px)`;
+        this.dragPreview.style.gridTemplateRows = `repeat(${rows}, 30px)`;
 
         block.shape.forEach(row => {
             row.forEach(cell => {


### PR DESCRIPTION
## 概要
ストックエリアで表示されるブロックのセル間に不要な隙間が発生していた問題を修正しました。

## 変更内容
- CSS Gridのサイズ指定を `auto` から `30px` の固定値に変更
- `js/block.js`: ストックエリアのブロック描画
- `js/input.js`: ドラッグプレビュー描画

## 関連Issue
Closes #28

----
Generated with [Claude Code](https://claude.ai/code)