### PR TITLE
Fix stock block rendering by adding CSS grid gap

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
 
         .block {
             display: grid;
-            gap: 0px;
+            gap: 2px;
             cursor: grab;
             padding: 5px;
             background: rgba(255, 255, 255, 0.1);
@@ -228,7 +228,7 @@
             z-index: 1000;
             opacity: 0.8;
             display: grid;
-            gap: 0px;
+            gap: 2px;
         }
 
         .drag-preview .block-cell {


### PR DESCRIPTION
## Summary
ストックエリアのブロック描画を修正しました。CSS Gridのgapを0pxから2pxに変更することで、セル間の適切なスペースを確保し、ブロックの形状が正しく表示されるようにしました。

## Changes
- `.block`クラスのgapを2pxに変更
- `.drag-preview`クラスのgapを2pxに変更
- ボードのセル間隔(2px)と統一

Closes #30

Generated with [Claude Code](https://claude.ai/code)