### PR TITLE
fix: バージョン情報を静的なタイムスタンプベースに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,23 +310,6 @@
 </head>
 <body>
     <div id="version-display"></div>
-    <script>
-        // バージョン情報を日本時間で表示
-        (function() {
-            const now = new Date();
-            const jstOffset = 9 * 60; // JST is UTC+9
-            const jstDate = new Date(now.getTime() + (jstOffset + now.getTimezoneOffset()) * 60000);
-
-            const year = jstDate.getFullYear();
-            const month = String(jstDate.getMonth() + 1).padStart(2, '0');
-            const day = String(jstDate.getDate()).padStart(2, '0');
-            const hours = String(jstDate.getHours()).padStart(2, '0');
-            const minutes = String(jstDate.getMinutes()).padStart(2, '0');
-
-            document.getElementById('version-display').textContent =
-                `Version: ${year}-${month}-${day} ${hours}:${minutes} JST`;
-        })();
-    </script>
     <h1>Woody Puzzle</h1>
     <div id="score-display">スコア: 0</div>
     <div id="highscore-display">ハイスコア: 0</div>
@@ -351,11 +334,42 @@
          3. block.js   - ブロック管理（生成、レンダリング、配置）
          4. input.js   - 入力処理（ドラッグ&ドロップ）
          5. main.js    - メイン処理（初期化、ゲームループ）
+
+         data-version属性: 各ファイルの最終更新日時（Unixタイムスタンプ）
     -->
-    <script src="js/ui.js"></script>
-    <script src="js/board.js"></script>
-    <script src="js/block.js"></script>
-    <script src="js/input.js"></script>
-    <script src="js/main.js"></script>
+    <script src="js/ui.js" data-version="1767792003"></script>
+    <script src="js/board.js" data-version="1767792003"></script>
+    <script src="js/block.js" data-version="1767792003"></script>
+    <script src="js/input.js" data-version="1767792003"></script>
+    <script src="js/main.js" data-version="1767792003"></script>
+    <script>
+        // バージョン情報を日本時間で表示（最も新しいJSファイルの更新日時を使用）
+        (function() {
+            // すべてのscriptタグからdata-version属性を取得
+            const scripts = document.querySelectorAll('script[data-version]');
+            let maxTimestamp = 0;
+
+            scripts.forEach(script => {
+                const timestamp = parseInt(script.getAttribute('data-version'), 10);
+                if (timestamp > maxTimestamp) {
+                    maxTimestamp = timestamp;
+                }
+            });
+
+            // Unixタイムスタンプから日本時間に変換
+            const date = new Date(maxTimestamp * 1000);
+            const jstOffset = 9 * 60; // JST is UTC+9
+            const jstDate = new Date(date.getTime() + (jstOffset + date.getTimezoneOffset()) * 60000);
+
+            const year = jstDate.getFullYear();
+            const month = String(jstDate.getMonth() + 1).padStart(2, '0');
+            const day = String(jstDate.getDate()).padStart(2, '0');
+            const hours = String(jstDate.getHours()).padStart(2, '0');
+            const minutes = String(jstDate.getMinutes()).padStart(2, '0');
+
+            document.getElementById('version-display').textContent =
+                `Version: ${year}-${month}-${day} ${hours}:${minutes} JST`;
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## 概要

Version情報がページリロードごとに変わる問題を修正しました。

## 変更内容

- 各JSファイルのscriptタグにdata-version属性を追加
- 最も新しいJSファイルの更新日時をバージョンとして表示
- new Date()による動的な日時生成を廃止

Closes #32

----

Generated with [Claude Code](https://claude.ai/code)