### PR TITLE
feat: タッチ操作時のドラッグオフセット機能を追加

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,4 +1,7 @@
 // ゲーム設定
 var CONFIG = {
-    VERSION: '__VERSION__'
+    VERSION: '__VERSION__',
+    // タッチ操作時のドラッグオフセット(px)
+    // ブロックが指で隠れないよう、指の位置より上に表示
+    TOUCH_DRAG_OFFSET_Y: 60
 };

--- a/js/input.js
+++ b/js/input.js
@@ -56,15 +56,17 @@ var InputHandler = {
         if (!InputHandler.draggedBlock) return;
         e.preventDefault();
         const touch = e.touches[0];
-        InputHandler.updateDragPreview(touch.clientX, touch.clientY);
+        InputHandler.updateDragPreview(touch.clientX, touch.clientY, true);
         InputHandler.highlightCells(touch.clientX, touch.clientY);
     },
 
     // ドラッグプレビューの更新
-    updateDragPreview: function(x, y) {
+    updateDragPreview: function(x, y, isTouch) {
         if (this.dragPreview) {
             this.dragPreview.style.left = (x - 40) + 'px';
-            this.dragPreview.style.top = (y - 40) + 'px';
+            // タッチ操作の場合はオフセットを適用
+            const offsetY = isTouch ? CONFIG.TOUCH_DRAG_OFFSET_Y : 0;
+            this.dragPreview.style.top = (y - 40 - offsetY) + 'px';
         }
     },
 


### PR DESCRIPTION
### 概要
タッチ操作時にブロックが指で隠れないよう、ドラッグプレビューの表示位置を指の位置より上にオフセットする機能を実装しました。

### 変更内容
- `config.js`に`TOUCH_DRAG_OFFSET_Y`設定を追加(デフォルト: 60px)
- `input.js`の`updateDragPreview`にタッチ判定を追加
- タッチ操作時、ブロックが指より上に表示されるよう調整

Closes #40

Generated with [Claude Code](https://claude.ai/code)