### PR TITLE
fix: ラウンド終了時の税金判定でゴールド額を正しく取得

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -76,7 +76,6 @@ var GameUI = {
         const deckInfoElement = document.getElementById('deck-info');
         if (deckInfoElement) {
             const taxAmount = BlockManager.gameState.taxRate;
-            const currentGold = BlockManager.gameState.gold;
 
             // 税金表示
             deckInfoElement.textContent = `ラウンド ${round} 終了！ 税金: ${taxAmount}ゴールド`;
@@ -86,6 +85,9 @@ var GameUI = {
 
             // 3秒後に税金支払い処理
             setTimeout(() => {
+                // 税金判定時に最新のゴールド額を取得（ライン消去で獲得したゴールドを含む）
+                const currentGold = BlockManager.gameState.gold;
+
                 if (currentGold >= taxAmount) {
                     // 税金支払い可能
                     BlockManager.gameState.gold -= taxAmount;


### PR DESCRIPTION
ラウンド終了時にライン消去で獲得したゴールドが税金判定に反映されないバグを修正。税金判定時（3秒後）に改めてゴールド額を取得することで、最新の状態を正しく判定できるようにしました。

Fixes #50

---

Generated with [Claude Code](https://claude.ai/code)