### PR TITLE
fix: 税金の上昇率を2ゴールド/ラウンドから1ゴールド/ラウンドに変更

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -93,8 +93,8 @@ var GameUI = {
                     BlockManager.gameState.gold -= taxAmount;
                     this.updateGold(0); // 表示更新
 
-                    // 次のラウンドの税金を計算（2n-1: 1, 3, 5, 7, 9...）
-                    BlockManager.gameState.taxRate += 2;
+                    // 次のラウンドの税金を計算（1, 2, 3, 4, 5...）
+                    BlockManager.gameState.taxRate += 1;
 
                     // UI リセット
                     deckInfoElement.style.background = '';


### PR DESCRIPTION
税金の上昇率を緩和しました。

### 変更内容
- `js/ui.js:97` - `taxRate += 2` → `taxRate += 1`
- 税金の推移: `1, 3, 5, 7, 9...` → `1, 2, 3, 4, 5...`

Closes #52

Generated with [Claude Code](https://claude.ai/code)