### PR TITLE
fix: ラウンド終了時の税金判定をゴールド獲得後に実行

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -339,6 +339,10 @@ var BlockManager = {
         // 3つすべて配置したかチェック
         const allPlaced = this.gameState.currentBlocks.every(b => b.placed);
         if (allPlaced) {
+            // ライン消去アニメーションの最大時間を計算
+            // 最大10マス × 50ms遅延 + 300ms アニメーション時間 = 800ms
+            const maxAnimationTime = (GameBoard.BOARD_SIZE * CONFIG.ANIMATION.DELAY_PER_BLOCK) + CONFIG.ANIMATION.DURATION;
+
             setTimeout(() => {
                 // デッキに残りがあれば次の3つを引く
                 if (this.gameState.deck.length > 0) {
@@ -348,9 +352,10 @@ var BlockManager = {
                     this.checkGameOver();
                 } else {
                     // デッキが空ならラウンド終了
+                    // ゴールド獲得処理が完全に終わってから表示
                     GameUI.showRoundEnd(this.gameState.round);
                 }
-            }, 600); // クリアアニメーション後に生成
+            }, maxAnimationTime + 50); // アニメーション完了後に確実にゴールドが反映されるよう余裕を持たせる
         } else {
             // まだ配置していないブロックがある場合
             // UI更新（配置済みブロックを除く）


### PR DESCRIPTION
## 概要
ラウンド終了時に、最後のブロック配置で獲得したゴールドが税金判定前に処理されないバグを修正しました。

## 変更内容
- ライン消去アニメーションの最大時間を動的に計算
- ゴールド獲得処理完了後にラウンド終了メッセージを表示
- 税金判定時に正確なゴールド額が反映されるように

Closes #58

---
Generated with [Claude Code](https://claude.ai/code)