### PR TITLE
fix: 存在しないupdateScore関数の呼び出しを削除してゴールド獲得を修正

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -180,23 +180,8 @@ var GameBoard = {
                 }
             });
 
-            // スコア計算
-            const totalLines = rows.length + cols.length;
-            let points = 0;
-
-            if (totalLines === 1) {
-                points = 100;
-            } else if (totalLines === 2) {
-                points = 300;
-            } else if (totalLines === 3) {
-                points = 500;
-            } else if (totalLines >= 4) {
-                points = 500 + (totalLines - 3) * 200;
-            }
-
-            GameUI.updateScore(points);
-
             // ゴールド獲得（消えたライン数だけゴールドを獲得）
+            const totalLines = rows.length + cols.length;
             if (totalLines > 0) {
                 GameUI.updateGold(totalLines);
             }


### PR DESCRIPTION
## 概要
ライン消去時にゴールドが獲得できないバグを修正しました。

## 原因
`js/board.js:197` で存在しない `GameUI.updateScore(points)` を呼び出していたため、JavaScriptエラーが発生し、その後の `GameUI.updateGold(totalLines)` の処理が実行されていませんでした。

スコアシステムはショップシステム実装時に削除されましたが、`board.js` の `updateScore` 呼び出しが残っていたことが原因です。

## 修正内容
- `js/board.js:183-197` のスコア計算処理と `updateScore` 呼び出しを削除
- ゴールド獲得処理のみを残すようにシンプル化

これにより、ライン消去時に正常にゴールドが獲得できるようになります。

Closes #58

---
Generated with [Claude Code](https://claude.ai/code)