### PR TITLE
fix: ショップ画面のブロック表示を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,11 +220,6 @@
                 width: 28px;
                 height: 28px;
             }
-
-            .shop-block {
-                grid-template-columns: repeat(auto-fit, 28px) !important;
-                grid-template-rows: repeat(auto-fit, 28px) !important;
-            }
         }
 
         @media (max-width: 380px) {
@@ -244,8 +239,6 @@
 
             .shop-block {
                 padding: 10px;
-                grid-template-columns: repeat(auto-fit, 25px) !important;
-                grid-template-rows: repeat(auto-fit, 25px) !important;
             }
         }
 

--- a/js/shop.js
+++ b/js/shop.js
@@ -98,8 +98,16 @@ var Shop = {
         const rows = block.shape.length;
         const cols = block.shape[0].length;
 
-        blockDiv.style.gridTemplateColumns = `repeat(${cols}, 35px)`;
-        blockDiv.style.gridTemplateRows = `repeat(${rows}, 35px)`;
+        // 画面幅に応じてセルサイズを調整
+        let cellSize = 35;
+        if (window.innerWidth <= 380) {
+            cellSize = 25;
+        } else if (window.innerWidth <= 480) {
+            cellSize = 28;
+        }
+
+        blockDiv.style.gridTemplateColumns = `repeat(${cols}, ${cellSize}px)`;
+        blockDiv.style.gridTemplateRows = `repeat(${rows}, ${cellSize}px)`;
 
         for (let row = 0; row < rows; row++) {
             for (let col = 0; col < cols; col++) {


### PR DESCRIPTION
ショップ画面でブロックが一列に表示される問題を修正しました。

## 変更内容
- `index.html`: モバイル向けメディアクエリから grid-template 指定を削除
- `js/shop.js`: 画面幅に応じてセルサイズを動的に調整するよう修正

Fixes #61

Generated with [Claude Code](https://claude.ai/code)