### PR TITLE
fix: ゲームオーバー判定をライン消去アニメーション完了後に実行

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -358,10 +358,17 @@ var BlockManager = {
             }, maxAnimationTime + 50); // アニメーション完了後に確実にゴールドが反映されるよう余裕を持たせる
         } else {
             // まだ配置していないブロックがある場合
+            // ライン消去アニメーションの最大時間を計算
+            const maxAnimationTime = (CONFIG.BOARD_SIZE * CONFIG.ANIMATION.DELAY_PER_BLOCK) + CONFIG.ANIMATION.DURATION;
+
             // UI更新（配置済みブロックを除く）
             const remainingInHand = this.gameState.currentBlocks.filter(b => !b.placed).length;
             GameUI.updateDeckInfo(this.gameState.deck.length + remainingInHand, this.gameState.round);
-            this.checkGameOver();
+
+            // ライン消去アニメーション完了後にゲームオーバーチェック
+            setTimeout(() => {
+                this.checkGameOver();
+            }, maxAnimationTime + 50);
         }
     },
 


### PR DESCRIPTION
### 概要
ブロック配置後のゲームオーバー判定が、ライン消去アニメーション完了前に実行されていたため、まだ配置可能なのにゲームオーバーになる問題を修正。

### 変更内容
- `placeBlock`関数で、全ブロック未配置時の`checkGameOver`呼び出しをライン消去アニメーション完了後に遅延実行するよう変更
- アニメーション時間(maxAnimationTime + 50ms)後に判定を実行

Fixes #69

---
Generated with [Claude Code](https://claude.ai/code)