### PR TITLE
ラウンド終了時に盤面とストックをリセット

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -375,6 +375,8 @@ var BlockManager = {
     // 次のラウンドを開始
     startNextRound: function() {
         this.gameState.round++;
+        // ボードをリセット
+        GameBoard.clear();
         // 初期デッキのコピーをシャッフルして再利用（新しいデッキは作成しない）
         this.gameState.deck = this.shuffleDeck([...this.gameState.initialDeck]);
         this.gameState.currentBlocks = this.drawBlocks();


### PR DESCRIPTION
## 概要
ラウンド終了時に盤面とストックをリセットする機能を追加しました。

## 変更内容
- `BlockManager.startNextRound()`で`GameBoard.clear()`を呼び出し、盤面をリセット
- ストックは既存の`drawBlocks()`で新しいブロックに置き換え

Fixes #71

Generated with [Claude Code](https://claude.ai/code)