### PR TITLE
ゴールド獲得額計算の修正

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -185,10 +185,12 @@ var GameBoard = {
                 }
             });
 
-            // ゴールド獲得（消えたライン数だけゴールドを獲得）
+            // ゴールド獲得（消滅した単位ブロック数 × 同時に消滅したライン数）
             const totalLines = rows.length + cols.length;
-            if (totalLines > 0) {
-                GameUI.updateGold(totalLines);
+            const totalBlocks = cellsToAnimate.length;
+            if (totalLines > 0 && totalBlocks > 0) {
+                const goldAmount = totalBlocks * totalLines;
+                GameUI.updateGold(goldAmount);
             }
         }, totalAnimationTime);
     }


### PR DESCRIPTION
ゴールドの獲得額計算ロジックを変更しました。

### 変更内容
- 従来: 消滅したライン数のみ
- 変更後: 消滅した単位ブロック数 × 同時に消滅したライン数

Fixes #73

---
Generated with [Claude Code](https://claude.ai/code)