### PR TITLE
税収制を目標スコア制に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
         }
 
-        #highscore-display, #gold-display {
+        #highscore-display, #score-display, #target-score-display {
             background: linear-gradient(135deg, #6d4c41 0%, #5d4037 100%);
             color: #fff;
             font-size: 24px;
@@ -43,7 +43,7 @@
             text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
         }
 
-        #highscore-display, #gold-display {
+        #highscore-display, #score-display, #target-score-display {
             font-size: 18px;
             background: linear-gradient(135deg, #8d6e63 0%, #795548 100%);
         }
@@ -434,7 +434,8 @@
     <div id="version-display"></div>
     <h1>Woody Puzzle</h1>
     <div id="highscore-display">最高ラウンド: 1</div>
-    <div id="gold-display">💰 ゴールド: 0</div>
+    <div id="score-display">スコア: 0</div>
+    <div id="target-score-display">目標スコア: 20</div>
     <div id="deck-info">ラウンド 1 - 残りブロック: 9/9</div>
 
     <div id="game-container">

--- a/js/block.js
+++ b/js/block.js
@@ -8,8 +8,7 @@ var BlockManager = {
         deck: [],           // 残りのデッキ
         currentBlocks: [],  // 現在の手札（3つ）
         round: 1,           // 現在のラウンド
-        gold: 0,            // 所持ゴールド
-        taxRate: 1          // 現在の税金額（初回は1）
+        score: 0            // 現在のスコア
     },
 
     // ブロックの定義（形状）- 3x3以内の全パターン（回転も別パターンとして扱う）
@@ -239,6 +238,7 @@ var BlockManager = {
 
         // UI更新
         GameUI.updateDeckInfo(this.gameState.deck.length + this.gameState.currentBlocks.length, this.gameState.round);
+        GameUI.updateTargetScore(this.gameState.round);
 
         this.checkGameOver();
     },
@@ -382,6 +382,7 @@ var BlockManager = {
         this.gameState.currentBlocks = this.drawBlocks();
         this.render();
         GameUI.updateDeckInfo(this.gameState.deck.length + this.gameState.currentBlocks.length, this.gameState.round);
+        GameUI.updateTargetScore(this.gameState.round);
         this.checkGameOver();
     },
 

--- a/js/board.js
+++ b/js/board.js
@@ -185,12 +185,12 @@ var GameBoard = {
                 }
             });
 
-            // ゴールド獲得（消滅した単位ブロック数 × 同時に消滅したライン数）
+            // スコア獲得（消滅した単位ブロック数 × 同時に消滅したライン数）
             const totalLines = rows.length + cols.length;
             const totalBlocks = cellsToAnimate.length;
             if (totalLines > 0 && totalBlocks > 0) {
-                const goldAmount = totalBlocks * totalLines;
-                GameUI.updateGold(goldAmount);
+                const scoreAmount = totalBlocks * totalLines;
+                GameUI.updateScore(scoreAmount);
             }
         }, totalAnimationTime);
     }

--- a/js/main.js
+++ b/js/main.js
@@ -12,15 +12,14 @@ function restartGame() {
     // ボードをクリア
     GameBoard.clear();
 
-    // ゴールドリセット
-    GameUI.resetGold();
+    // スコアリセット
+    GameUI.resetScore();
 
     // UIリセット
     GameUI.hideGameOver();
 
-    // ラウンドと税金をリセット
+    // ラウンドをリセット
     BlockManager.gameState.round = 1;
-    BlockManager.gameState.taxRate = 1;
 
     // 新しいブロックを生成
     BlockManager.init();

--- a/js/ui.js
+++ b/js/ui.js
@@ -24,16 +24,22 @@ var GameUI = {
         }
     },
 
-    // ゴールド更新
-    updateGold: function(amount) {
-        BlockManager.gameState.gold += amount;
-        document.getElementById('gold-display').textContent = `💰 ゴールド: ${BlockManager.gameState.gold}`;
+    // スコア更新
+    updateScore: function(amount) {
+        BlockManager.gameState.score += amount;
+        document.getElementById('score-display').textContent = `スコア: ${BlockManager.gameState.score}`;
     },
 
-    // ゴールドリセット
-    resetGold: function() {
-        BlockManager.gameState.gold = 0;
-        document.getElementById('gold-display').textContent = `💰 ゴールド: 0`;
+    // スコアリセット
+    resetScore: function() {
+        BlockManager.gameState.score = 0;
+        document.getElementById('score-display').textContent = `スコア: 0`;
+    },
+
+    // 目標スコア表示更新
+    updateTargetScore: function(round) {
+        const targetScore = round * 20;
+        document.getElementById('target-score-display').textContent = `目標スコア: ${targetScore}`;
     },
 
     // ゲームオーバー画面を表示
@@ -63,27 +69,19 @@ var GameUI = {
     showRoundEnd: function(round) {
         const deckInfoElement = document.getElementById('deck-info');
         if (deckInfoElement) {
-            const taxAmount = BlockManager.gameState.taxRate;
+            const targetScore = round * 20;
+            const currentScore = BlockManager.gameState.score;
 
-            // 税金表示
-            deckInfoElement.textContent = `ラウンド ${round} 終了！ 税金: ${taxAmount}ゴールド`;
-            deckInfoElement.style.background = 'linear-gradient(135deg, #f57c00 0%, #e65100 100%)';
-            deckInfoElement.style.color = '#fff';
-            deckInfoElement.style.fontWeight = 'bold';
+            // 目標スコア判定
+            if (currentScore >= targetScore) {
+                // 目標達成！
+                deckInfoElement.textContent = `ラウンド ${round} クリア！ 目標達成！`;
+                deckInfoElement.style.background = 'linear-gradient(135deg, #66bb6a 0%, #43a047 100%)';
+                deckInfoElement.style.color = '#fff';
+                deckInfoElement.style.fontWeight = 'bold';
 
-            // 3秒後に税金支払い処理
-            setTimeout(() => {
-                // 税金判定時に最新のゴールド額を取得（ライン消去で獲得したゴールドを含む）
-                const currentGold = BlockManager.gameState.gold;
-
-                if (currentGold >= taxAmount) {
-                    // 税金支払い可能
-                    BlockManager.gameState.gold -= taxAmount;
-                    this.updateGold(0); // 表示更新
-
-                    // 次のラウンドの税金を計算（1, 2, 3, 4, 5...）
-                    BlockManager.gameState.taxRate += 1;
-
+                // 3秒後にショップ表示
+                setTimeout(() => {
                     // UI リセット
                     deckInfoElement.style.background = '';
                     deckInfoElement.style.color = '';
@@ -91,12 +89,12 @@ var GameUI = {
 
                     // ショップを表示
                     Shop.show();
-                } else {
-                    // 税金支払い不可 → ゲームオーバー
-                    this.saveHighScore();
-                    this.showGameOver(`税金を支払えませんでした（必要: ${taxAmount}ゴールド、所持: ${currentGold}ゴールド）`);
-                }
-            }, 3000);
+                }, 3000);
+            } else {
+                // 目標未達成 → ゲームオーバー
+                this.saveHighScore();
+                this.showGameOver(`目標スコアに到達できませんでした（目標: ${targetScore}、獲得: ${currentScore}）`);
+            }
         }
     }
 };


### PR DESCRIPTION
## 概要
税収制をやめて目標スコア制に変更しました。

## 変更内容
- ゴールドをスコアに名称変更
- 税金支払いシステムを削除
- 目標スコアシステムを実装（ラウンド × 20）
- 目標スコア表示をUIに追加
- ラウンドクリア条件を目標スコア達成に変更
- スコアはラウンド間で引き継ぎ

Fixes #75

—
Generated with [Claude Code](https://claude.ai/code)