### PR TITLE
スコア演出修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,91 @@
             }
         }
 
+        /* スコア演出用のスタイル */
+        .block-popup {
+            position: fixed;
+            font-size: 24px;
+            font-weight: bold;
+            color: #ffd700;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
+            pointer-events: none;
+            z-index: 1500;
+            animation: blockPopupAnimation 0.6s ease-out forwards;
+        }
+
+        @keyframes blockPopupAnimation {
+            0% {
+                opacity: 0;
+                transform: translateY(0) scale(0.5);
+            }
+            30% {
+                opacity: 1;
+                transform: translateY(-30px) scale(1.2);
+            }
+            100% {
+                opacity: 0;
+                transform: translateY(-60px) scale(1);
+            }
+        }
+
+        #score-effect-display {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(62, 39, 35, 0.95);
+            color: #ffd700;
+            font-size: 48px;
+            font-weight: bold;
+            padding: 30px 50px;
+            border-radius: 20px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+            z-index: 1600;
+            pointer-events: none;
+            text-align: center;
+            line-height: 1.5;
+            display: none;
+        }
+
+        #score-effect-display.show {
+            display: block;
+            animation: scoreEffectFadeIn 0.3s ease-out;
+        }
+
+        @keyframes scoreEffectFadeIn {
+            from {
+                opacity: 0;
+                transform: translate(-50%, -50%) scale(0.8);
+            }
+            to {
+                opacity: 1;
+                transform: translate(-50%, -50%) scale(1);
+            }
+        }
+
+        @media (max-width: 480px) {
+            .block-popup {
+                font-size: 20px;
+            }
+
+            #score-effect-display {
+                font-size: 36px;
+                padding: 20px 40px;
+            }
+        }
+
+        @media (max-width: 380px) {
+            .block-popup {
+                font-size: 18px;
+            }
+
+            #score-effect-display {
+                font-size: 28px;
+                padding: 15px 30px;
+            }
+        }
+
         #blocks-container {
             display: flex;
             justify-content: center;
@@ -442,6 +527,8 @@
         <div id="board"></div>
         <div id="blocks-container"></div>
     </div>
+
+    <div id="score-effect-display"></div>
 
     <div id="game-over-screen" style="display: none;">
         <div id="game-over-content">

--- a/js/board.js
+++ b/js/board.js
@@ -157,7 +157,7 @@ var GameBoard = {
             }
         });
 
-        // 各セルにアニメーションを適用
+        // 各セルにアニメーションを適用 + 「+1」ポップアップを表示
         cellsToAnimate.forEach(cellData => {
             setTimeout(() => {
                 const cellElement = document.querySelector(
@@ -165,6 +165,12 @@ var GameBoard = {
                 );
                 if (cellElement) {
                     cellElement.classList.add('clearing');
+
+                    // セルの中心座標を取得して「+1」ポップアップを表示
+                    const rect = cellElement.getBoundingClientRect();
+                    const centerX = rect.left + rect.width / 2;
+                    const centerY = rect.top + rect.height / 2;
+                    GameUI.showBlockPopup(centerX, centerY);
                 }
             }, cellData.delay);
         });
@@ -185,12 +191,13 @@ var GameBoard = {
                 }
             });
 
-            // スコア獲得（消滅した単位ブロック数 × 同時に消滅したライン数）
+            // スコア演出を表示（消滅した単位ブロック数 × 同時に消滅したライン数）
             const totalLines = rows.length + cols.length;
             const totalBlocks = cellsToAnimate.length;
             if (totalLines > 0 && totalBlocks > 0) {
                 const scoreAmount = totalBlocks * totalLines;
-                GameUI.updateScore(scoreAmount);
+                // スコア計算演出を表示（演出内でスコアがインクリメントされる）
+                GameUI.showScoreCalculation(totalBlocks, totalLines, scoreAmount);
             }
         }, totalAnimationTime);
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -24,10 +24,78 @@ var GameUI = {
         }
     },
 
-    // スコア更新
+    // スコア更新（演出なし）
     updateScore: function(amount) {
         BlockManager.gameState.score += amount;
         document.getElementById('score-display').textContent = `スコア: ${BlockManager.gameState.score}`;
+    },
+
+    // 単位ブロック「+1」ポップアップを表示
+    showBlockPopup: function(x, y) {
+        const popup = document.createElement('div');
+        popup.className = 'block-popup';
+        popup.textContent = '+1';
+        popup.style.left = x + 'px';
+        popup.style.top = y + 'px';
+        document.body.appendChild(popup);
+
+        // アニメーション終了後に削除
+        setTimeout(() => {
+            if (popup.parentNode) {
+                popup.parentNode.removeChild(popup);
+            }
+        }, 600);
+    },
+
+    // スコア計算演出を表示
+    showScoreCalculation: function(totalBlocks, totalLines, scoreAmount) {
+        const display = document.getElementById('score-effect-display');
+        if (!display) return;
+
+        // 第1段階: ブロック数 × ライン数
+        display.innerHTML = `${totalBlocks}<br>×<br>${totalLines}ライン`;
+        display.classList.add('show');
+
+        // 1秒後に第2段階: 計算結果とスコアインクリメント
+        setTimeout(() => {
+            display.innerHTML = `${scoreAmount}`;
+            this.animateScoreIncrement(scoreAmount);
+        }, 1000);
+
+        // さらに1秒後に非表示
+        setTimeout(() => {
+            display.classList.remove('show');
+        }, 2000);
+    },
+
+    // スコアのインクリメントアニメーション
+    animateScoreIncrement: function(targetAmount) {
+        const startScore = BlockManager.gameState.score;
+        const endScore = startScore + targetAmount;
+        const duration = 800; // 0.8秒
+        const startTime = Date.now();
+
+        const animate = () => {
+            const elapsed = Date.now() - startTime;
+            const progress = Math.min(elapsed / duration, 1);
+
+            // イージング関数（easeOutCubic）
+            const easeProgress = 1 - Math.pow(1 - progress, 3);
+            const currentScore = Math.floor(startScore + (targetAmount * easeProgress));
+
+            BlockManager.gameState.score = currentScore;
+            document.getElementById('score-display').textContent = `スコア: ${currentScore}`;
+
+            if (progress < 1) {
+                requestAnimationFrame(animate);
+            } else {
+                // 最終的な正確な値を設定
+                BlockManager.gameState.score = endScore;
+                document.getElementById('score-display').textContent = `スコア: ${endScore}`;
+            }
+        };
+
+        requestAnimationFrame(animate);
     },
 
     // スコアリセット


### PR DESCRIPTION
##81 スコア演出修正

## 実装内容

ブロック消滅時の段階的なスコア演出を実装しました:

- 単位ブロック消滅時に「+1」ポップアップアニメーションを追加
- 盤面中央に「ブロック数 × ライン数」→「計算結果」の段階的表示を追加
- スコアのインクリメントアニメーションを実装
- レスポンシブデザイン対応

## 変更ファイル
- `index.html` - スコア演出用CSS・HTML要素を追加
- `js/ui.js` - 演出関数を追加
- `js/board.js` - 演出呼び出し処理を追加

Generated with [Claude Code](https://claude.ai/code)