### PR TITLE
ラウンド終了時にスコアを0にリセット

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -397,6 +397,8 @@ var BlockManager = {
     // 次のラウンドを開始
     startNextRound: function() {
         this.gameState.round++;
+        // スコアをリセット
+        GameUI.resetScore();
         // ボードをリセット
         GameBoard.clear();
         // 初期デッキのコピーをシャッフルして再利用（新しいデッキは作成しない）


### PR DESCRIPTION
## 概要
ラウンド終了時にスコアを0にリセットする機能を追加しました。

## 変更内容
- `BlockManager.startNextRound()`メソッドで`GameUI.resetScore()`を呼び出し
- 新しいラウンド開始時にスコアを0にリセット

Fixes #85

---
Generated with [Claude Code](https://claude.ai/code)