### PR TITLE
データリセット機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,31 @@
             font-family: monospace;
         }
 
+        #settings-icon {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background: rgba(62, 39, 35, 0.7);
+            color: #fff;
+            font-size: 24px;
+            padding: 8px 12px;
+            border-radius: 5px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+            z-index: 1000;
+            cursor: pointer;
+            transition: all 0.2s;
+            user-select: none;
+        }
+
+        #settings-icon:hover {
+            background: rgba(62, 39, 35, 0.9);
+            transform: scale(1.1);
+        }
+
+        #settings-icon:active {
+            transform: scale(0.95);
+        }
+
         #game-over-screen {
             position: fixed;
             top: 0;
@@ -517,6 +542,7 @@
 </head>
 <body>
     <div id="version-display"></div>
+    <div id="settings-icon">⚙️</div>
     <h1>Woody Puzzle</h1>
     <div id="highscore-display">最高ラウンド: 1</div>
     <div id="score-display">スコア: 0</div>

--- a/js/main.js
+++ b/js/main.js
@@ -29,4 +29,5 @@ function restartGame() {
 document.addEventListener('DOMContentLoaded', function() {
     initGame();
     document.getElementById('restart-button').addEventListener('click', restartGame);
+    GameUI.initSettingsIcon();
 });

--- a/js/ui.js
+++ b/js/ui.js
@@ -164,5 +164,32 @@ var GameUI = {
                 this.showGameOver(`目標スコアに到達できませんでした（目標: ${targetScore}、獲得: ${currentScore}）`);
             }
         }
+    },
+
+    // データリセット機能
+    resetData: function() {
+        if (confirm('データをリセットしますか？')) {
+            // localStorageをクリア
+            localStorage.clear();
+            // ページをリロード
+            window.location.reload();
+        }
+    },
+
+    // 設定アイコンのイベントリスナーを初期化
+    initSettingsIcon: function() {
+        const settingsIcon = document.getElementById('settings-icon');
+        if (settingsIcon) {
+            // クリックイベント（PC用）
+            settingsIcon.addEventListener('click', function() {
+                GameUI.resetData();
+            });
+
+            // タッチイベント（モバイル用）
+            settingsIcon.addEventListener('touchend', function(e) {
+                e.preventDefault(); // デフォルトのタッチ動作を防止
+                GameUI.resetData();
+            });
+        }
     }
 };


### PR DESCRIPTION
## 概要
画面右上に設定アイコン（⚙️）を追加し、データリセット機能を実装しました。

## 変更内容
- 画面右上に設定アイコン（⚙️）を表示
- タップすると確認ダイアログを表示
- OKを押すとlocalStorageをクリアしてリロード
- ハイスコアを含む全ての保存データを削除可能

Closes #89

—
Generated with [Claude Code](https://claude.ai/code)