### PR TITLE
fix: ストックブロックのリフレッシュ待ち時間を削除

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -360,9 +360,8 @@ var BlockManager = {
         // UI更新
         GameUI.updatePlacementInfo(this.gameState.blocksPlacedCount, this.gameState.round);
 
-        // スコア加算アニメーション完了後にスコアチェック
-        // animateScoreIncrement()のduration(800ms) + スコア演出の遅延(1000ms) + 余裕(200ms)
-        const scoreAnimationTime = maxAnimationTime + 2000;
+        // ライン消去アニメーション完了後にスコアチェック
+        const scoreAnimationTime = maxAnimationTime;
 
         setTimeout(() => {
             // 目標スコアに達成したかチェック


### PR DESCRIPTION
## 概要
ストックのブロックを全て配置してから次のブロックが表示されるまでの待ち時間を削除しました。

## 変更内容
- `js/block.js`のplaceBlockメソッドで、不要な2秒の遅延を削除
- ライン消去アニメーション完了後、即座に次のブロックが表示されるように修正

Closes #91

🤖 Generated with [Claude Code](https://claude.ai/code)