### PR TITLE
fix: スコアアニメーション完了後にゲームオーバー判定を実行

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -351,19 +351,13 @@ var BlockManager = {
         this.gameState.blocksPlacedCount++;
         this.render();
 
-        // 行・列のクリアチェック
-        GameBoard.checkAndClearLines();
-
-        // ライン消去アニメーションの最大時間を計算
-        const maxAnimationTime = (CONFIG.BOARD_SIZE * CONFIG.ANIMATION.DELAY_PER_BLOCK) + CONFIG.ANIMATION.DURATION;
-
         // UI更新
         GameUI.updatePlacementInfo(this.gameState.blocksPlacedCount, this.gameState.round);
 
-        // ライン消去アニメーション完了後にスコアチェック
-        const scoreAnimationTime = maxAnimationTime;
+        // 行・列のクリアチェック（スコアアニメーション完了後にコールバックが呼ばれる）
+        GameBoard.checkAndClearLines(() => {
+            // スコアアニメーション完了後に実行される処理
 
-        setTimeout(() => {
             // 目標スコアに達成したかチェック
             const targetScore = this.gameState.round * 20;
             if (this.gameState.score >= targetScore) {
@@ -390,7 +384,7 @@ var BlockManager = {
                 // ゲームオーバーチェック
                 this.checkGameOver();
             }
-        }, scoreAnimationTime);
+        });
     },
 
     // 次のラウンドを開始

--- a/js/board.js
+++ b/js/board.js
@@ -91,7 +91,7 @@ var GameBoard = {
     },
 
     // 完成した行・列をチェック
-    checkAndClearLines: function() {
+    checkAndClearLines: function(onComplete) {
         const rowsToClear = [];
         const colsToClear = [];
 
@@ -118,14 +118,19 @@ var GameBoard = {
 
         // クリア処理
         if (rowsToClear.length > 0 || colsToClear.length > 0) {
-            this.clearLines(rowsToClear, colsToClear);
+            this.clearLines(rowsToClear, colsToClear, onComplete);
+        } else {
+            // ラインがクリアされなかった場合もコールバックを呼ぶ
+            if (onComplete) {
+                onComplete();
+            }
         }
 
         return rowsToClear.length + colsToClear.length;
     },
 
     // 行・列をクリア
-    clearLines: function(rows, cols) {
+    clearLines: function(rows, cols, onComplete) {
         // アニメーション用のセル配列（順序付き）
         const cellsToAnimate = [];
 
@@ -197,7 +202,13 @@ var GameBoard = {
             if (totalLines > 0 && totalBlocks > 0) {
                 const scoreAmount = totalBlocks * totalLines;
                 // スコア計算演出を表示（演出内でスコアがインクリメントされる）
-                GameUI.showScoreCalculation(totalBlocks, totalLines, scoreAmount);
+                // スコアアニメーション完了後にonCompleteコールバックを呼ぶ
+                GameUI.showScoreCalculation(totalBlocks, totalLines, scoreAmount, onComplete);
+            } else {
+                // ラインがクリアされなかった場合もコールバックを呼ぶ
+                if (onComplete) {
+                    onComplete();
+                }
             }
         }, totalAnimationTime);
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -48,9 +48,13 @@ var GameUI = {
     },
 
     // スコア計算演出を表示
-    showScoreCalculation: function(totalBlocks, totalLines, scoreAmount) {
+    showScoreCalculation: function(totalBlocks, totalLines, scoreAmount, callback) {
         const display = document.getElementById('score-effect-display');
-        if (!display) return;
+        if (!display) {
+            // displayが存在しない場合でも、スコアは加算してコールバックを呼ぶ
+            this.animateScoreIncrement(scoreAmount, callback);
+            return;
+        }
 
         // 第1段階: ブロック数 × ライン数
         display.innerHTML = `${totalBlocks}<br>×<br>${totalLines}ライン`;
@@ -59,7 +63,7 @@ var GameUI = {
         // 1秒後に第2段階: 計算結果とスコアインクリメント
         setTimeout(() => {
             display.innerHTML = `${scoreAmount}`;
-            this.animateScoreIncrement(scoreAmount);
+            this.animateScoreIncrement(scoreAmount, callback);
         }, 1000);
 
         // さらに1秒後に非表示
@@ -69,7 +73,7 @@ var GameUI = {
     },
 
     // スコアのインクリメントアニメーション
-    animateScoreIncrement: function(targetAmount) {
+    animateScoreIncrement: function(targetAmount, callback) {
         const startScore = BlockManager.gameState.score;
         const endScore = startScore + targetAmount;
         const duration = 800; // 0.8秒
@@ -92,6 +96,11 @@ var GameUI = {
                 // 最終的な正確な値を設定
                 BlockManager.gameState.score = endScore;
                 document.getElementById('score-display').textContent = `スコア: ${endScore}`;
+
+                // コールバックが指定されている場合は実行
+                if (callback) {
+                    callback();
+                }
             }
         };
 


### PR DESCRIPTION
ゲームオーバー判定がスコア加算のアニメーション完了前に実行されていた問題を修正。
スコアアニメーションが完了してから目標スコア達成判定とゲームオーバー判定を
行うようにコールバック機構を導入しました。

変更内容:
- ui.js: animateScoreIncrementとshowScoreCalculationにコールバック引数を追加
- board.js: checkAndClearLinesとclearLinesにコールバック引数を追加
- block.js: placeBlockでsetTimeoutの代わりにコールバックを使用