### PR TITLE
ブロックが置けない場合の処理を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,62 @@
             }
         }
 
+        #cannot-place-dialog {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(62, 39, 35, 0.95);
+            color: #fff;
+            font-size: 24px;
+            font-weight: bold;
+            padding: 30px 40px;
+            border-radius: 15px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+            z-index: 1700;
+            text-align: center;
+            display: none;
+        }
+
+        #cannot-place-dialog.show {
+            display: block;
+            animation: fadeInOut 3s ease-out;
+        }
+
+        @keyframes fadeInOut {
+            0% {
+                opacity: 0;
+                transform: translate(-50%, -50%) scale(0.8);
+            }
+            15% {
+                opacity: 1;
+                transform: translate(-50%, -50%) scale(1);
+            }
+            85% {
+                opacity: 1;
+                transform: translate(-50%, -50%) scale(1);
+            }
+            100% {
+                opacity: 0;
+                transform: translate(-50%, -50%) scale(0.8);
+            }
+        }
+
+        @media (max-width: 480px) {
+            #cannot-place-dialog {
+                font-size: 20px;
+                padding: 25px 35px;
+            }
+        }
+
+        @media (max-width: 380px) {
+            #cannot-place-dialog {
+                font-size: 18px;
+                padding: 20px 30px;
+            }
+        }
+
         #game-container {
             display: flex;
             flex-direction: column;
@@ -555,6 +611,7 @@
     </div>
 
     <div id="score-effect-display"></div>
+    <div id="cannot-place-dialog"></div>
 
     <div id="game-over-screen" style="display: none;">
         <div id="game-over-content">

--- a/js/block.js
+++ b/js/block.js
@@ -338,8 +338,44 @@ var BlockManager = {
     // ゲームオーバーチェック
     checkGameOver: function() {
         if (!this.canPlaceAnyBlock()) {
-            GameUI.saveHighScore();
-            GameUI.showGameOver();
+            // 配置できないブロックの数を数える
+            let unplaceableCount = 0;
+            for (const block of this.gameState.currentBlocks) {
+                if (!block.placed) {
+                    unplaceableCount++;
+                }
+            }
+
+            // ダイアログを表示して、コールバックで後処理を実行
+            GameUI.showCannotPlaceDialog(() => {
+                // 配置できないブロックをすべて「配置済み」としてマーク
+                for (const block of this.gameState.currentBlocks) {
+                    if (!block.placed) {
+                        block.placed = true;
+                        this.gameState.blocksPlacedCount++;
+                    }
+                }
+
+                // UI更新
+                this.render();
+                GameUI.updatePlacementInfo(this.gameState.blocksPlacedCount, this.gameState.round);
+
+                // 残りの配置可能数が12に達したかチェック
+                if (this.gameState.blocksPlacedCount >= 12) {
+                    // ラウンド終了処理
+                    this.gameState.roundEnding = true;
+                    GameUI.showRoundEnd(this.gameState.round);
+                } else {
+                    // まだ残りがある場合は次の3つを引く
+                    const allPlaced = this.gameState.currentBlocks.every(b => b.placed);
+                    if (allPlaced) {
+                        this.gameState.currentBlocks = this.drawBlocks();
+                        this.render();
+                        // 再度チェック（新しいブロックも置けない場合がある）
+                        this.checkGameOver();
+                    }
+                }
+            });
         }
     },
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -178,6 +178,29 @@ var GameUI = {
         }
     },
 
+    // 「どこにもブロックを置けません」ダイアログを表示
+    showCannotPlaceDialog: function(callback) {
+        const dialog = document.getElementById('cannot-place-dialog');
+        if (!dialog) {
+            // ダイアログ要素が存在しない場合でもコールバックを呼ぶ
+            if (callback) {
+                setTimeout(callback, 3000);
+            }
+            return;
+        }
+
+        dialog.textContent = 'どこにもブロックを置けません';
+        dialog.classList.add('show');
+
+        // 3秒後に非表示にしてコールバックを実行
+        setTimeout(() => {
+            dialog.classList.remove('show');
+            if (callback) {
+                callback();
+            }
+        }, 3000);
+    },
+
     // データリセット機能
     resetData: function() {
         if (confirm('データをリセットしますか？')) {


### PR DESCRIPTION
## 概要
盤面にストックにあるブロックが置けなくても、即座にゲームオーバーにせず、ダイアログを表示してブロックをスキップする処理を実装。

## 変更内容
- 「どこにもブロックを置けません」ダイアログを追加
- 配置できないブロックを自動スキップ
- 残り配置可能数が残っていればゲーム続行

Fixes #97

Generated with [Claude Code](https://claude.ai/code)