### PR TITLE
fix: ゲームオーバー後の再プレイでブロックが配置できない問題を修正

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -138,5 +138,33 @@ var InputHandler = {
         document.removeEventListener('touchend', InputHandler.onDragEnd);
 
         InputHandler.draggedBlock = null;
+    },
+
+    // 入力ハンドラーをリセット
+    reset: function() {
+        // イベントリスナーをすべて削除
+        document.removeEventListener('mousemove', this.onDragMove);
+        document.removeEventListener('mouseup', this.onDragEnd);
+        document.removeEventListener('touchmove', this.onTouchMove);
+        document.removeEventListener('touchend', this.onDragEnd);
+
+        // ドラッグプレビューを削除
+        if (this.dragPreview) {
+            this.dragPreview.remove();
+            this.dragPreview = null;
+        }
+
+        // すべてのハイライトをクリア
+        document.querySelectorAll('.cell').forEach(cell => {
+            cell.classList.remove('highlight', 'invalid');
+        });
+
+        // draggingクラスを削除
+        document.querySelectorAll('.block.dragging').forEach(block => {
+            block.classList.remove('dragging');
+        });
+
+        // 状態をリセット
+        this.draggedBlock = null;
     }
 };

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,9 @@ function initGame() {
 
 // ゲームリスタート
 function restartGame() {
+    // 入力ハンドラーをリセット
+    InputHandler.reset();
+
     // ボードをクリア
     GameBoard.clear();
 


### PR DESCRIPTION
## 概要
ゲームオーバー後に「もう一度遊ぶ」をクリックすると、ブロックが配置できなくなるバグを修正しました。

## 変更内容
- `InputHandler.reset()`メソッドを追加
  - イベントリスナーの完全なクリーンアップ
  - ドラッグプレビュー要素の削除
  - ハイライトとdraggingクラスのクリア
  - 内部状態のリセット
- `restartGame()`で`InputHandler.reset()`を呼び出す

Fixes #103

Generated with [Claude Code](https://claude.ai/code)